### PR TITLE
[issue-32] Fix how_did_they_hear migration

### DIFF
--- a/database/migrations/2017_07_05_121947_update_table_users_add_column_how_did_they_hear.php
+++ b/database/migrations/2017_07_05_121947_update_table_users_add_column_how_did_they_hear.php
@@ -14,7 +14,7 @@ class UpdateTableUsersAddColumnHowDidTheyHear extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('how_did_they_hear')->after('notes');
+            $table->string('how_did_they_hear')->after('notes')->nullable();
         });
     }
 


### PR DESCRIPTION
Fixes #32. Set `how_did_they_hear` default value `null`.